### PR TITLE
Install birdhoused

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -21,6 +21,7 @@ modules:
       - rclone
       - fuse-devel
       - cheese
+      - nodejs
       # Presentation machine packages
       - libreoffice
       - nextcloud-client
@@ -51,6 +52,10 @@ modules:
       - zz1-gnome-shell-extensions.gschema.override
       - zz1-set-gnome-shell-dock.gschema.override
       - zz1-suppress-autosuspend.gschema.override
+  - type: containerfile
+    snippets:
+      # TODO figure out why, without --no-bin-links, npm throws EROFS on chmod() on index.js... which SEEMINGLY is actually the creation of a symlink?
+      - RUN --mount=type=bind,src=apps/birdhoused,dst=/tmp/birdhoused cd /tmp/birdhoused && npm --no-bin-links --prefix=/usr install -g --omit=dev
   - type: files
     files:
       - source: usr


### PR DESCRIPTION
WIP:

```
l/av-linux:latest => #39 [av-linux 11/21] RUN --mount=type=bind,src=apps/birdhoused,dst=/tmp/birdhoused cd /tmp/birdhoused && npm --prefix=/usr install -g --production
l/av-linux:latest => #39 1.235 npm warn config production Use `--omit=dev` instead.
l/av-linux:latest => #39 1.965 npm error code EROFS
l/av-linux:latest => #39 1.965 npm error syscall chmod
l/av-linux:latest => #39 1.965 npm error path /usr/lib/node_modules/birdhouse-client/index.js
l/av-linux:latest => #39 1.967 npm error errno -30
l/av-linux:latest => #39 1.968 npm error rofs EROFS: read-only file system, chmod '/usr/lib/node_modules/birdhouse-client/index.js'
l/av-linux:latest => #39 1.968 npm error rofs Often virtualized file systems, or other file systems
l/av-linux:latest => #39 1.968 npm error rofs that don't support symlinks, give this error.
l/av-linux:latest => #39 1.976 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-10-27T05_08_39_966Z-debug-0.log
l/av-linux:latest => #39 ERROR: process "/bin/sh -c cd /tmp/birdhoused && npm --prefix=/usr install -g --production" did not complete successfully: exit code: 226
l/av-linux:latest => ------
l/av-linux:latest =>  > [av-linux 11/21] RUN --mount=type=bind,src=apps/birdhoused,dst=/tmp/birdhoused cd /tmp/birdhoused && npm --prefix=/usr install -g --production:
l/av-linux:latest => 1.235 npm warn config production Use `--omit=dev` instead.
l/av-linux:latest => 1.965 npm error code EROFS
l/av-linux:latest => 1.965 npm error syscall chmod
l/av-linux:latest => 1.965 npm error path /usr/lib/node_modules/birdhouse-client/index.js
l/av-linux:latest => 1.967 npm error errno -30
l/av-linux:latest => 1.968 npm error rofs EROFS: read-only file system, chmod '/usr/lib/node_modules/birdhouse-client/index.js'
l/av-linux:latest => 1.968 npm error rofs Often virtualized file systems, or other file systems
l/av-linux:latest => 1.968 npm error rofs that don't support symlinks, give this error.
l/av-linux:latest => 1.976 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-10-27T05_08_39_966Z-debug-0.log
l/av-linux:latest => ------
```